### PR TITLE
Change getFilters to use 'old' array syntax

### DIFF
--- a/hacksaw/twigextensions/HacksawTwigExtension.php
+++ b/hacksaw/twigextensions/HacksawTwigExtension.php
@@ -11,43 +11,47 @@ class HacksawTwigExtension extends Twig_Extension
 	{
 		return 'Hacksaw';
 	}
-	
+
 	public function getFilters()
 	{
 		return array(
-			'hacksaw' => new Twig_Filter_Method( $this, 'HacksawFilter',['is_safe'=>['html']] )
+			'hacksaw' => new Twig_Filter_Method( $this, 'HacksawFilter',
+				array(
+					'is_safe' => array('html')
+				)
+			)
 		);
 	}
-	
+
 	public function HacksawFilter( $content, $chars_start='0', $chars='', $words='', $cutoff='', $append='', $allow='' )
 	{
-	
+
 		if(isset($cutoff) && $cutoff != "") {
-		
+
 			$cutoff_content = $this->_truncate_cutoff($content, $cutoff, $words, $allow, $append);
-			
+
 			// Strip the HTML
 			$new_content = (strpos($content, $cutoff) ? strip_tags($cutoff_content, $allow) : strip_tags($cutoff_content, $allow));
 
 		} elseif (isset($chars) && $chars != "") {
-		
+
 			// Strip the HTML
 			$stripped_content = strip_tags($content, $allow);
-			
+
 			$new_content = (strlen($stripped_content) <= $chars ? $stripped_content : $this->_truncate_chars($stripped_content, $chars_start, $chars, $append));
 
 		} elseif (isset($words) && $words != "") {
 
 			// Strip the HTML
 			$stripped_content = strip_tags($content, $allow);
-			
+
 			$new_content = (str_word_count($stripped_content) <= $words ? $stripped_content : $this->_truncate_words($stripped_content, $words, $append));
 
 		} else {
 
 			// Strip the HTML
 			$stripped_content = strip_tags($content, $allow);
-			
+
 			$new_content = $stripped_content;
 
 		}
@@ -58,63 +62,63 @@ class HacksawTwigExtension extends Twig_Extension
 
 	// Helper Function - Truncate by Word Limit
 	function _truncate_words($content, $limit, $append) {
-		
+
 		$num_words = str_word_count($content, 0);
-		
+
 		if ($num_words > $limit) {
-			
+
 			$words = str_word_count($content, 2);
-			
+
 			$pos = array_keys($words);
 
 			$content = substr($content, 0, ($pos[$limit]-1)) . $append;
-		
+
 		}
-		
+
 		return $content;
 
     }
-    
+
 	// Helper Function - Truncate by Character Limit
 	function _truncate_chars($content, $chars_start, $limit, $append) {
 
-		// Removing the below to see how it effect UTF-8. 
+		// Removing the below to see how it effect UTF-8.
 	    $content = preg_replace('/\s+?(\S+)?$/', '', substr($content, $chars_start, ($limit+1))) . $append;
 
 		return $content;
-		
+
 	}
-	
+
 	// Helper Function - Truncate by Cutoff Marker
 	function _truncate_cutoff($content, $cutoff, $words, $allow, $append) {
-	
+
 		$pos = strpos($content, $cutoff);
-		
+
 		if ($pos != FALSE) {
-			
+
 			$content = substr($content, 0, $pos) . $append;
 
 		} elseif ($words != "") {
-			
+
 			$content = $this->_truncate_words(strip_tags($content, $allow), $words, '') . $append;
 		}
-		
+
 		return $content;
 
 	}
-	
+
 	function _close_tags($content) {
-		
+
 		preg_match_all('#<(?!meta|img|br|hr|input\b)\b([a-z]+)(?: .*)?(?<![/|/ ])>#iU', $content, $result);
-		
+
 		$openedtags = $result[1];
-		
+
 		preg_match_all('#</([a-z]+)>#iU', $content, $result);
-		
+
 		$closedtags = $result[1];
-		
+
 		$len_opened = count($openedtags);
-		
+
 		if (count($closedtags) == $len_opened) {
 
 			return $content;
@@ -138,7 +142,7 @@ class HacksawTwigExtension extends Twig_Extension
 		}
 
 		return $content;
-		
-	} 
+
+	}
 
 }


### PR DESCRIPTION
Craft requires PHP 5.3.0. The array in the getFilters function is PHP 5.4 or newer and could potentially break Craft installs on 5.3.
