### PR TITLE
Revert "Convert content to HTML entities when using the 'words' param"

### DIFF
--- a/hacksaw/twigextensions/HacksawTwigExtension.php
+++ b/hacksaw/twigextensions/HacksawTwigExtension.php
@@ -43,9 +43,6 @@ class HacksawTwigExtension extends Twig_Extension
 
 			// Strip the HTML
 			$stripped_content = strip_tags($content, $allow);
-			
-			// Convert everything to HTML entities
-			$stripped_content = htmlentities($content);
 
 			$new_content = (str_word_count($stripped_content) <= $words ? $stripped_content : $this->_truncate_words($stripped_content, $words, $append));
 


### PR DESCRIPTION
With this update, the `allow` parameter breaks. I will look into a better, longer-term solution for this.