### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Hacksaw 1.1.2
+# Hacksaw 1.1.2
 
 A simple text truncation plugin for [Craft CMS](http://buildwithcraft.com/). This plugin adds a [Twig](http://twig.sensiolabs.org/) filter to take your entry's content and hack it down to a more manageable size. It strips the HTML and limits the excerpts by character count, word count, or cutoff marker.
 
@@ -55,7 +55,7 @@ This would append "..." to the end of the excerpt.
 {{ entry.richTextField|hacksaw(words='100', allow='<a>', append='<a href="' ~ entry.url ~ '">Continue...</a>') }}
 ```
 
-##Roadmap
+## Roadmap
 - Add truncation by number of paragraphs
 
 ## Feedback?


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
